### PR TITLE
Additional endpoints for role specific actions and related services

### DIFF
--- a/book-market/src/main/java/mb/projects/book_market/Config/DataLoader.java
+++ b/book-market/src/main/java/mb/projects/book_market/Config/DataLoader.java
@@ -34,24 +34,28 @@ public class DataLoader implements CommandLineRunner {
 
             User user1 = new User("Raj", "Kumar", "rajkumar@bookmarket.com", passwordEncoder.encode("pass"), "raj444");
             user1.setIsDeleted(false);
+            user1.setIsBanned(false);
             user1.setRole(Role.ADMIN);
             userRepository.save(user1);
 
             User user2 = new User("Ryan", "Thompson", "ryanthompson@bookmarket.com", passwordEncoder.encode("pass"),
                     "ryry_t");
             user2.setIsDeleted(false);
+            user2.setIsBanned(false);
             user2.setRole(Role.STANDARD);
             userRepository.save(user2);
 
             User user3 = new User("Alex", "Poirier", "alexpoirier@bookmarket.com", passwordEncoder.encode("pass"),
                     "apple_poirier");
             user3.setIsDeleted(false);
+            user3.setIsBanned(false);
             user3.setRole(Role.STANDARD);
             userRepository.save(user3);
 
             User user4 = new User("Cheah", "Davos", "cheahdavos@bookmarket.com", passwordEncoder.encode("pass"),
                     "cheah-12-d");
             user4.setIsDeleted(false);
+            user4.setIsBanned(false);
             user4.setRole(Role.STANDARD);
             userRepository.save(user4);
 

--- a/book-market/src/main/java/mb/projects/book_market/Enums/UserBanCause.java
+++ b/book-market/src/main/java/mb/projects/book_market/Enums/UserBanCause.java
@@ -1,0 +1,21 @@
+package mb.projects.book_market.Enums;
+
+public enum UserBanCause {
+    ANTISOCIAL_BEHAVIOUR("Antisocial Behaviour"),
+    FRAUDULENT_ACTIVITY("Fraudulent Activity"),
+    HARMFUL_CONTENT("Harmful Content"),
+    SPAMMING("Spamming"),
+    HARASSMENT("Harassment"),
+    VIOLATING_PRIVACY_POLICIES("Violating Privacy Policies");
+    
+    private final String displayName;
+
+    UserBanCause(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+}

--- a/book-market/src/main/java/mb/projects/book_market/Trade/TradeController.java
+++ b/book-market/src/main/java/mb/projects/book_market/Trade/TradeController.java
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.mail.MessagingException;
-
+import mb.projects.book_market.Enums.Role;
+import mb.projects.book_market.Role.AllowedRoles;
 
 @RestController
 @RequestMapping("/trades")
@@ -26,16 +27,37 @@ public class TradeController {
         this.service = service;
     }
 
+    @AllowedRoles({ Role.ADMIN })
     @GetMapping()
     public ResponseEntity<List<Trade>> getAllTrades() {
         List<Trade> allTrades = service.getAllTrades();
         return new ResponseEntity<>(allTrades, HttpStatus.OK);
     }
 
+    @GetMapping("/user={id}")
+    public ResponseEntity<List<Trade>> getAllTradesByUser(@PathVariable Long id) {
+        List<Trade> allTradesByUser = service.getAllTradesByUser(id);
+        return new ResponseEntity<>(allTradesByUser, HttpStatus.OK);
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<Trade> getTradeById(@PathVariable Long id) {
         Trade result = service.getTradeById(id);
         return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @AllowedRoles({ Role.ADMIN })
+    @GetMapping("/all/{status}")
+    public ResponseEntity<List<Trade>> getTradesByStatus(@PathVariable String status) {
+        List<Trade> tradesByStatus = service.getTradesByStatus(status);
+        return new ResponseEntity<>(tradesByStatus, HttpStatus.OK);
+    }
+
+    @AllowedRoles({ Role.ADMIN })
+    @GetMapping("/{tradeType}/{userId}") // filter by offering a trade or receiving a trade
+    public ResponseEntity<List<Trade>> getTradeByUserAndType(@PathVariable Long userId, @PathVariable String tradeType) {
+        List<Trade> tradesByUser = service.getTradesByUserAndTradeType(userId, tradeType);
+        return new ResponseEntity<>(tradesByUser, HttpStatus.OK);
     }
 
     @PostMapping()
@@ -49,7 +71,7 @@ public class TradeController {
         Trade updatedTrade = service.updateTrade(id, tradeData);
         return new ResponseEntity<>(updatedTrade, HttpStatus.OK);
     }
-    
+
     @PatchMapping("/approve/{id}")
     public void approveTrade(@PathVariable Long id) throws MessagingException {
         service.approveTrade(id);
@@ -60,6 +82,7 @@ public class TradeController {
         service.declineTrade(id);
     }
 
+    @AllowedRoles({ Role.ADMIN })
     @DeleteMapping("/{id}")
     public HttpStatus cancelTrade(@PathVariable Long id) {
         service.cancelTrade(id);

--- a/book-market/src/main/java/mb/projects/book_market/Trade/TradeService.java
+++ b/book-market/src/main/java/mb/projects/book_market/Trade/TradeService.java
@@ -1,7 +1,10 @@
 package mb.projects.book_market.Trade;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -106,7 +109,6 @@ public class TradeService {
                 userReceiving.getFirstName(), userReceiving.getEmail(),
                 bookOffered.getTitle(), bookReceived.getTitle(), "Approved");
 
-
         // Here the swap happens: userReceiving gets the bookOffered
         // and userOffering gets the bookRequested
         bookService.tradeBook(trade.getBookOffered(), userReceiving.getId());
@@ -132,6 +134,47 @@ public class TradeService {
         emailService.tradeUpdateMessage(userOffering.getFirstName(), userOffering.getEmail(),
                 userReceiving.getFirstName(), userReceiving.getEmail(),
                 bookOffered.getTitle(), bookReceived.getTitle(), "Declined");
+    }
+
+    public List<Trade> getAllTradesByUser(Long id) {
+        Optional<User> found = this.userRepo.findById(id);
+        if (found.isEmpty()) {
+            return null;
+        }
+        User result = found.get();
+        List<Trade> allTrades = getAllTrades();
+        return allTrades.stream().filter(trade ->  trade.getUserOffering().equals(result) || trade.getUserReceiving().equals(result))
+        .collect(Collectors.toList());
+    }
+
+    public List<Trade> getTradesByUserAndTradeType(Long id, String tradeType) {
+        Optional<User> found = this.userRepo.findById(id);
+        if (found.isEmpty()) {
+            return null;
+        }
+        User result = found.get();
+
+        List<Trade> allTrades = getAllTrades();
+
+        List<Trade> tradesFiltered = new ArrayList<Trade>();
+
+        if (tradeType.equalsIgnoreCase("offering")) {
+            tradesFiltered = allTrades.stream().filter(trade -> trade.getUserOffering().equals(result))
+                    .collect(Collectors.toList());
+        }
+
+        if (tradeType.equalsIgnoreCase("receiving")) {
+            tradesFiltered = allTrades.stream().filter(trade -> trade.getUserReceiving().equals(result))
+                    .collect(Collectors.toList());
+        }
+
+        return tradesFiltered;
+    }
+
+    public List<Trade> getTradesByStatus(String status) {
+        List<Trade> allTrades = getAllTrades();
+        return allTrades.stream().filter(trade -> trade.getTradeStatus().getDisplayName().equalsIgnoreCase(status))
+                .collect(Collectors.toList());
     }
 
 }

--- a/book-market/src/main/java/mb/projects/book_market/User/User.java
+++ b/book-market/src/main/java/mb/projects/book_market/User/User.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import mb.projects.book_market.Book.Book;
 import mb.projects.book_market.Enums.Role;
+import mb.projects.book_market.Enums.UserBanCause;
 
 @Data
 @Entity
@@ -61,6 +62,15 @@ public class User implements UserDetails {
 
     @Column
     private Boolean isDeleted;
+
+    @Column
+    private Boolean isBanned;
+    
+    @Column
+    private UserBanCause cause;
+
+    @Column
+    private String notesAboutBan;
 
     @CreationTimestamp
     private Instant createdOn;

--- a/book-market/src/main/java/mb/projects/book_market/User/UserBanDTO.java
+++ b/book-market/src/main/java/mb/projects/book_market/User/UserBanDTO.java
@@ -1,0 +1,19 @@
+package mb.projects.book_market.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import mb.projects.book_market.Enums.UserBanCause;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserBanDTO {
+
+    private Boolean isBanned;
+
+    private UserBanCause cause;
+
+    private String notesAboutBan;
+
+}

--- a/book-market/src/main/java/mb/projects/book_market/User/UserController.java
+++ b/book-market/src/main/java/mb/projects/book_market/User/UserController.java
@@ -13,19 +13,34 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import mb.projects.book_market.Enums.Role;
+import mb.projects.book_market.Role.AllowedRoles;
+import mb.projects.book_market.Trade.TradeRepository;
+
 @RestController
 @RequestMapping("/users")
 public class UserController {
 
     UserService userService;
+    TradeRepository tradeRepo;
     
-    public UserController(UserService userService) {
+    public UserController(UserService userService, TradeRepository tradeRepo) {
         this.userService = userService;
+        this.tradeRepo = tradeRepo;
     }
 
+    @AllowedRoles({Role.ADMIN})
     @GetMapping()
     public ResponseEntity<List<User>> getAllUsers(){
         List<User> allUsers = userService.getAllUsers();
+        System.out.println("users: " + allUsers.size());
+        return new ResponseEntity<>(allUsers, HttpStatus.OK);      
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<List<User>> getAllActiveUsers(){
+        List<User> allUsers = userService.getAllActiveUsers();
+        System.out.println("users: " + allUsers.size());
         return new ResponseEntity<>(allUsers, HttpStatus.OK);      
     }
 
@@ -50,6 +65,12 @@ public class UserController {
     @DeleteMapping("/{id}")
     public String deleteUser(@PathVariable Long id) {
         return userService.deleteUser(id);
+    }
+
+    @AllowedRoles({Role.ADMIN})
+    @PatchMapping("/ban/{id}") 
+    public String banUser(@PathVariable Long id, @RequestBody UserBanDTO userBanDTO){
+        return userService.banUser(id, userBanDTO);
     }
 
 }

--- a/book-market/src/main/java/mb/projects/book_market/User/UserDTO.java
+++ b/book-market/src/main/java/mb/projects/book_market/User/UserDTO.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import mb.projects.book_market.Book.Book;
 import mb.projects.book_market.Enums.Role;
+import mb.projects.book_market.Enums.UserBanCause;
 
 @Data
 @AllArgsConstructor
@@ -28,5 +29,9 @@ public class UserDTO {
     private List<Book> books;
 
     private Boolean isDeleted = Boolean.FALSE;
+
+    private Boolean isBanned = Boolean.FALSE;
+
+    private UserBanCause cause;
 
 }

--- a/book-market/src/main/java/mb/projects/book_market/User/UserService.java
+++ b/book-market/src/main/java/mb/projects/book_market/User/UserService.java
@@ -2,6 +2,7 @@ package mb.projects.book_market.User;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,11 @@ public class UserService {
 
     public List<User> getAllUsers() {
         return repo.findAll();
+    }
+
+    public List<User> getAllActiveUsers() {
+        List<User> allUsers = getAllUsers();
+        return allUsers.stream().filter(user -> user.getIsBanned().equals(Boolean.FALSE) && user.getIsDeleted().equals(Boolean.FALSE)).collect(Collectors.toList());
     }
 
     public User getUserById(Long id) {
@@ -65,7 +71,22 @@ public class UserService {
         }
         User result = found.get();
         result.setIsDeleted(true);
+        repo.save(result);
         return "Successfully deleted User with ID: " + id;
+    }
+
+    public String banUser(Long id, UserBanDTO userBanDTO) {
+       Optional<User> found = this.repo.findById(id);
+        if (found.isEmpty()) {
+            return null;
+        }
+        User result = found.get();
+        result.setIsBanned(Boolean.TRUE);
+        result.setCause(userBanDTO.getCause());
+        result.setNotesAboutBan(userBanDTO.getNotesAboutBan());
+        repo.save(result);
+
+        return "Successfully banned User with ID: " + id + "due to " + userBanDTO.getCause().getDisplayName()+" notes: " + userBanDTO.getNotesAboutBan();
     }
 
 }


### PR DESCRIPTION
- Create Admin role specific actions
    - Can access all users (banned and deleted)
    - Can access all trades initiated (all status)
    - Can access trades, filtered offered or receiving trade by user
    - Can access trades, filtered by their status pending/approved/declined
    - Cancel/Delete a trade
- Create any roles actions
    - Can access only active users
    - Can access their own trades, regardless of status